### PR TITLE
Update jetty dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-# Created by .ignore support plugin (hsz.mobi)
 .idea*
+*.iml
 target/*

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.ONSdigital</groupId>
+    <groupId>com.github.onsdigital</groupId>
     <artifactId>restolino</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Restolino</name>
     <description>
@@ -52,12 +52,12 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.14.v20181114</version>
+            <version>9.4.28.v20200408</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-security</artifactId>
-            <version>9.4.14.v20181114</version>
+            <version>9.4.28.v20200408</version>
         </dependency>
 
         <!-- Commons -->

--- a/src/main/java/com/github/davidcarboni/restolino/framework/PriorityComparator.java
+++ b/src/main/java/com/github/davidcarboni/restolino/framework/PriorityComparator.java
@@ -3,7 +3,7 @@ package com.github.davidcarboni.restolino.framework;
 import java.util.Comparator;
 
 /**
- * {@link Comparator} impl for classes that use the {@link Priority} annotation. Objects are order by {@link Priority#priority()}
+ * {@link Comparator} impl for classes that use the {@link Priority} annotation. Objects are order by {@link Priority#value()}
  * if they implement it or by Class name if they don't / if two priorities are equal.
  */
 public class PriorityComparator implements Comparator<Object> {


### PR DESCRIPTION
Update jetty dependency to 9.4.28.
This will likely become v0.2.1 of the ONS restolino fork.

Anyone can review.