### PR TITLE
fix defect where temp files are not being deleted

### DIFF
--- a/src/main/java/com/github/davidcarboni/restolino/json/Serialiser.java
+++ b/src/main/java/com/github/davidcarboni/restolino/json/Serialiser.java
@@ -150,11 +150,11 @@ public class Serialiser {
             return;
         }
 
-        LOG.info("attempting to delete temp file creating by serialise method file:{}", temp.getFileName().toString());
+        LOG.info("attempting to delete temp file creating by serialise method file:{}", temp.toString());
 
         if (!Files.deleteIfExists(temp)) {
             LOG.warn("attempt to delete temp file was unsucessful, file has been added to deleteOnExit list " +
-                    "and will be removed when the JVM shutdown normally, file: {}", temp.getFileName().toString());
+                    "and will be removed when the JVM shutdown normally, file: {}", temp.toString());
             temp.toFile().deleteOnExit();
         }
     }

--- a/src/main/java/com/github/davidcarboni/restolino/json/Serialiser.java
+++ b/src/main/java/com/github/davidcarboni/restolino/json/Serialiser.java
@@ -146,11 +146,11 @@ public class Serialiser {
 
     private static void deleteTempFile(Path temp) throws IOException {
         if (temp == null) {
-            LOG.debug("temp file is null no clean up required");
+            LOG.info("temp file is null no clean up required");
             return;
         }
 
-        LOG.debug("attempting to delete temp file creating by serialise method file:{}", temp.getFileName().toString());
+        LOG.info("attempting to delete temp file creating by serialise method file:{}", temp.getFileName().toString());
 
         if (!Files.deleteIfExists(temp)) {
             LOG.warn("attempt to delete temp file was unsucessful, file has been added to deleteOnExit list " +

--- a/src/main/java/com/github/davidcarboni/restolino/json/Serialiser.java
+++ b/src/main/java/com/github/davidcarboni/restolino/json/Serialiser.java
@@ -146,15 +146,14 @@ public class Serialiser {
 
     private static void deleteTempFile(Path temp) throws IOException {
         if (temp == null) {
-            LOG.info("temp file is null no clean up required");
+            LOG.debug("temp file is null no clean up required");
             return;
         }
 
-        LOG.info("attempting to delete temp file creating by serialise method file:{}", temp.toString());
-
+        LOG.debug("attempting to delete temp file created by serialise method file:{}", temp.toString());
         if (!Files.deleteIfExists(temp)) {
-            LOG.warn("attempt to delete temp file was unsucessful, file has been added to deleteOnExit list " +
-                    "and will be removed when the JVM shutdown normally, file: {}", temp.toString());
+            LOG.warn("attempt to delete temp file was unsuccessful, file has been added to deleteOnExit list " +
+                    "and will be removed when the JVM is shutdown, file: {}", temp.toString());
             temp.toFile().deleteOnExit();
         }
     }
@@ -167,6 +166,7 @@ public class Serialiser {
         //  However, this functionality is it at the centre of the website and publishing services so I've made a
         //  concious tactical decision to only fix the immediate problem of ensuring the temp files are deleted rather
         //  than rewriting/refactoring this whole process and risk introducing a regression.
+
         // First serialise to a temp file
         Gson gson = getBuilder().create();
         try (Writer writer = Files.newBufferedWriter(temp, StandardCharsets.UTF_8)) {
@@ -184,27 +184,6 @@ public class Serialiser {
             outputChannel.truncate(size);
         }
     }
-/*
-    public static void serialise(Path output, Object json) throws IOException {
-
-        // First serialise to a temp file:
-        Gson gson = getBuilder().create();
-        Path temp = Files.createTempFile(json.getClass().getSimpleName(), ".json");
-        try (Writer writer = Files.newBufferedWriter(temp, StandardCharsets.UTF_8)) {
-            gson.toJson(json, writer);
-        }
-
-        // Now do an optimised Channel-to-Channel transfer to the output file:
-        long size = Files.size(temp);
-        try (FileChannel tempChannel = FileChannel.open(temp, StandardOpenOption.READ);
-             FileChannel outputChannel = FileChannel.open(output, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
-            // NB the lock will be released when the channel is closed:
-            writeLock(outputChannel);
-            outputChannel.truncate(0);
-            tempChannel.transferTo(0, size, outputChannel);
-            outputChannel.truncate(size);
-        }
-    }*/
 
     /**
      * Deserialises the given {@link InputStream} to a JSON String.

--- a/src/main/java/com/github/davidcarboni/restolino/json/Serialiser.java
+++ b/src/main/java/com/github/davidcarboni/restolino/json/Serialiser.java
@@ -160,12 +160,15 @@ public class Serialiser {
 
     private static void writeJsonObjectToFile(Path temp, Path output, Object json) throws IOException {
         // TODO
-        //  To fix defect Trello #616 I've refactored this code to ensure that the temp file is deleted immeditely
-        //  after use.
-        //  I am not sure why this first step of serialising to a temp file is required it seems unncessary to me?
-        //  However, this functionality is it at the centre of the website and publishing services so I've made a
-        //  concious tactical decision to only fix the immediate problem of ensuring the temp files are deleted rather
-        //  than rewriting/refactoring this whole process and risk introducing a regression.
+        //  Fix for defect Trello #616:
+        //  Refactored serialise method to ensure temp files are deleted immediately after use. These files are not
+        //  used again and over time this results in large amounts of disk space being consumed unnecessarily.
+        //  It's not clear why the first step in serialise needs to be written to a temp file - there could be a
+        //  technical reason for this but it's not documented anywhere.
+        //  As this functionality is it at the centre of the website and publishing services we've made a conscious
+        //  tactical decision to hold off removing this step. For now we have implemented a fix to ensure any temp
+        //  files are cleaned up which will fix our immediate problem whilst reducing the risk introducing
+        //  a regression into core publishing services.
 
         // First serialise to a temp file
         Gson gson = getBuilder().create();


### PR DESCRIPTION
### Defect 616
Prod/Dev Zebedee cannot write content to disk and needs to be restarted.

#### Summary
The `Serialiser.serialise()` is creating temp files each time an object is being marshalled to JSON and written to disk. These temp files are not being cleaned up after use so over time the app fills up the available `tmp` disk space.  When the `tmp` dir has reached full capacity any request using `Serialiser.serialise()` will fail and content cannot be written to disk. 

I believe there was a misunderstanding around what a temp file is -> previously a temp file was created but not deleted after use but after consulting the java doc its clearly stated that you have to manually delete these files and they will not be cleaned up automatically.

https://docs.oracle.com/javase/7/docs/api/java/io/File.html#createTempFile%28java.lang.String,%20java.lang.String,%20java.io.File%29

https://docs.oracle.com/javase/7/docs/api/java/io/File.html#deleteOnExit%28%29

This will affect any request that results in a write action to update any file in the CMS - content, collections, users, sessions etc. This is why the impact/symptoms of this issue are so wide ranging.

For clarification this issue is specifically related to the `tmp` dir not the CMS storage volume where the content is actually stored. Even if the volume has sufficient disk space available once the tmp dir is full any write action going via `Serialiser.serialise()` will result in an error before the content is saved.

It is unclear what the purpose of the temp files is, my gut feeling is they are completely unnecessary but in the interest of minimising the possible risk of changing a central part of the publishing system I have consciously chosen to fix the temp file clean up problem and not refactor this process.

#### Whats changed.
Ive updated the serialise code  to use a `finally` block to ensure that these tmp files are deleted once they are no longer needed.