### PR TITLE
Return 404 if files have not been served

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.onsdigital</groupId>
     <artifactId>restolino</artifactId>
-    <version>0.2.2-SNAPSHOT</version>
+    <version>undefined</version>
     <packaging>jar</packaging>
     <name>Restolino</name>
     <description>

--- a/src/main/java/com/github/davidcarboni/restolino/jetty/MainHandler.java
+++ b/src/main/java/com/github/davidcarboni/restolino/jetty/MainHandler.java
@@ -134,14 +134,15 @@ public class MainHandler extends HandlerCollection {
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
 
-        // Should we try redirecting to index.html?
-        boolean isApiRequest = isApiRequest(target);
         try {
             if (preFilter(request, response)) {
-                if (isApiRequest) {
+                if (isApiRequest(target)) {
                     apiHandler.handle(target, baseRequest, request, response);
                 } else if (filesHandler != null) {
                     filesHandler.handle(target, baseRequest, request, response);
+                    if (!baseRequest.isHandled()) {
+                        notFound(target, response);
+                    }
                 } else {
                     notFound(target, response);
                 }


### PR DESCRIPTION
Babbage returns a 200 when called with a file extension with an HTTP verb which is not a GET request

We will now return 404 unless the file handler has actually handled the request