### PR TITLE
Make jetty max threads configurable

### DIFF
--- a/src/main/java/com/github/davidcarboni/restolino/Configuration.java
+++ b/src/main/java/com/github/davidcarboni/restolino/Configuration.java
@@ -22,6 +22,7 @@ public class Configuration {
 
     private static final Logger log = getLogger(Configuration.class);
     public static final String PORT = "PORT";
+    public static final String JETTY_MAX_THREADS = "JETTY_MAX_THREADS";
     public static final String CLASSES = "restolino.classes";
     public static final String PACKAGE_PREFIX = "restolino.packageprefix";
     public static final String FILES = "restolino.files";
@@ -34,6 +35,11 @@ public class Configuration {
      * The Jetty server port.
      */
     public int port = 8080;
+
+    /**
+     * The Jetty server max threads.
+     */
+    public int maxThreads = 200;
 
     /**
      * If files will be dynamically reloaded, true.
@@ -142,8 +148,9 @@ public class Configuration {
 
     public Configuration() {
 
-        // The server port:
+        // The server port and maxThreads:
         String port = getValue(PORT);
+        String maxThreads = getValue(JETTY_MAX_THREADS);
 
         // The reloadable parameters:
         String files = getValue(FILES);
@@ -156,6 +163,7 @@ public class Configuration {
 
         // Set up the configuration:
         configurePort(port);
+        configureMaxThreads(maxThreads);
         configureFiles(files);
         configureClasses(classes);
         configureAuthentication(username, password, realm);
@@ -175,6 +183,24 @@ public class Configuration {
                 log.info("Using port {}", this.port);
             } catch (NumberFormatException e) {
                 log.info("Unable to parse server PORT variable ({}). Defaulting to port {}", port, this.port);
+            }
+        }
+    }
+
+    /**
+     * Configures the server max threads by attempting to parse the given parameter,
+     * but failing gracefully if that doesn't work out.
+     *
+     * @param maxThreads The value of the {@value #JETTY_MAX_THREADS} parameter.
+     */
+    void configureMaxThreads(String maxThreads) {
+
+        if (StringUtils.isNotBlank(maxThreads)) {
+            try {
+                this.maxThreads = Integer.parseInt(maxThreads);
+                log.info("Using maxThreads {}", this.maxThreads);
+            } catch (NumberFormatException e) {
+                log.info("Unable to parse server JETTY_MAX_THREADS variable ({}). Defaulting to maxThreads {}", maxThreads, this.maxThreads);
             }
         }
     }

--- a/src/main/java/com/github/davidcarboni/restolino/Main.java
+++ b/src/main/java/com/github/davidcarboni/restolino/Main.java
@@ -5,9 +5,12 @@ import com.github.davidcarboni.restolino.jetty.MainHandler;
 import com.github.davidcarboni.restolino.reload.ClassReloader;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.slf4j.Logger;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -43,7 +46,11 @@ public class Main {
             configuration = new Configuration();
 
             // Create the Jetty server
-            server = new Server(configuration.port);
+            QueuedThreadPool qtp = new QueuedThreadPool(configuration.maxThreads);
+            org.eclipse.jetty.server.Server server = new Server(qtp);
+            ServerConnector http = new ServerConnector(server, new HttpConnectionFactory());
+            http.setPort(configuration.port);
+            server.addConnector(http);
 
             // Create the handlers
             mainHandler = new MainHandler();


### PR DESCRIPTION
Make jetty max threads configurable by use of the `JETTY_MAX_THREADS` environment variable 