### PR TITLE
Feature/update external dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.46.v20220331</jetty.version>
+        <jetty.version>9.4.53.v20231009</jetty.version>
     </properties>
 
     <dependencies>
@@ -65,22 +65,22 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.11</version>
+            <version>3.14.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.9.0</version>
+            <version>2.15.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>2.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.12</version>
+            <version>0.10.2</version>
         </dependency>
 
         <!-- Logging -->
@@ -113,7 +113,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -125,7 +125,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>
@@ -142,7 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -158,7 +158,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -174,7 +174,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.6.3</version>
                 <executions>
                     <execution>
                         <id>attach-javadoc</id>
@@ -200,7 +200,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>
@@ -212,7 +212,7 @@
             <plugin>
                 <groupId>org.sonatype.ossindex.maven</groupId>
                 <artifactId>ossindex-maven-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>audit-dependencies-critical</id>

--- a/src/main/java/com/github/davidcarboni/restolino/reload/ClassFinder.java
+++ b/src/main/java/com/github/davidcarboni/restolino/reload/ClassFinder.java
@@ -40,7 +40,7 @@ public class ClassFinder {
 
         // We set up reflections to use the classLoader for loading classes
         // and also to use the classLoader to determine the list of URLs:
-        ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().addClassLoader(classLoader);
+        ConfigurationBuilder configurationBuilder = new ConfigurationBuilder().addClassLoaders(classLoader);
         if (StringUtils.isNotBlank(packagePrefix)) {
             configurationBuilder.addUrls(ClasspathHelper.forPackage(packagePrefix, classLoader));
         } else {


### PR DESCRIPTION
### What

Updated minor versions of dependencies and plugins
Updated one method call as new library version changed name of method slighly

### How to review

Check out this branch
Add this snippet to your plugin section in your pom.xml file
```
<plugin>
                <groupId>org.codehaus.mojo</groupId>
                <artifactId>versions-maven-plugin</artifactId>
                <version>2.16.2</version>
</plugin>
```
Be sure you have current java 1.8 installed and is being used  by maven. Maven uses the JDK from the current JAVA_HOME environment variable. You can set JAVA_HOME to  your java jdk 1.8 home.

for example on mac os when you installed jdk1.8 with brew : export JAVA_HOME=/usr/local/Cellar/openjdk@8/1.8.0-392/
execute:

mvn versions:display-dependency-updates -DallowMajorUpdates=false
mvn versions:display-plugin-updates

This should not bring up any new updates.
`mvn test` and `mvn package should compile without error`


### Who can review

member of ONS 