### PR TITLE
Feature configure http request header size limit for jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.onsdigital</groupId>
     <artifactId>restolino</artifactId>
-    <version>undefined</version>
+    <version>0.8.0</version>
     <packaging>jar</packaging>
     <name>Restolino</name>
     <description>

--- a/src/main/java/com/github/davidcarboni/restolino/Configuration.java
+++ b/src/main/java/com/github/davidcarboni/restolino/Configuration.java
@@ -183,8 +183,7 @@ public class Configuration {
     }
 
     /**
-      * Configures the server request header size,
-      * default is 8192 bytes.
+      * Configures the server request header size.
       *
       * @param requestHeaderSize The value of the {@value #JETTY_REQUEST_HEADER_SIZE} parameter.
       */

--- a/src/main/java/com/github/davidcarboni/restolino/Configuration.java
+++ b/src/main/java/com/github/davidcarboni/restolino/Configuration.java
@@ -170,11 +170,8 @@ public class Configuration {
         String realm = getValue(AUTH_REALM);
 
         // server request header size:
+        System.setProperty(JETTY_REQUEST_HEADER_SIZE, StringUtils.EMPTY);
         String requestHeaderSize = getValue(JETTY_REQUEST_HEADER_SIZE);
-        // if the env var is not set use default value
-        if (StringUtils.isBlank(requestHeaderSize)) {
-            requestHeaderSize = Integer.toString(this.jettyRequestHeaderSize);
-        }
 
         // Set up the configuration:
         configurePort(port);
@@ -192,13 +189,11 @@ public class Configuration {
       * @param requestHeaderSize The value of the {@value #JETTY_REQUEST_HEADER_SIZE} parameter.
       */
     void configureJettyRequestHeaderSize(String requestHeaderSize) {
-        if (StringUtils.isNotBlank(requestHeaderSize)) {
-            try {
-                this.jettyRequestHeaderSize = Integer.parseInt(requestHeaderSize);
-                log.info("Using jettyRequestHeaderSize {}", this.jettyRequestHeaderSize);
-            } catch (NumberFormatException e) {
-                log.info("Unable to parse server JETTY_REQUEST_HEADER_SIZE variable ({}). Defaulting to jettyRequestHeaderSize {}", requestHeaderSize, this.jettyRequestHeaderSize);
-            }
+        try {
+            this.jettyRequestHeaderSize = Integer.parseInt(requestHeaderSize);
+            log.info("Using jettyRequestHeaderSize {}", this.jettyRequestHeaderSize);
+        } catch (NumberFormatException e) {
+            log.info("Unable to parse server JETTY_REQUEST_HEADER_SIZE variable ({}). Defaulting to jettyRequestHeaderSize {}", requestHeaderSize, this.jettyRequestHeaderSize);
         }
     }
 

--- a/src/main/java/com/github/davidcarboni/restolino/Configuration.java
+++ b/src/main/java/com/github/davidcarboni/restolino/Configuration.java
@@ -31,6 +31,8 @@ public class Configuration {
     public static final String AUTH_PASSWORD = "restolino.password";
     public static final String AUTH_REALM = "restolino.realm";
 
+    public static final String JETTY_REQUEST_HEADER_SIZE = "JETTY_REQUEST_HEADER_SIZE";
+
     /**
      * The Jetty server port.
      */
@@ -112,6 +114,11 @@ public class Configuration {
      */
     public String realm;
 
+    /**
+     * The Jetty server request header size.
+     */
+    public int jettyRequestHeaderSize = 8192;
+
     @Override
     public String toString() {
 
@@ -132,6 +139,7 @@ public class Configuration {
         result.append("\n - classesInClasspath:\t" + classesInClasspath);
         result.append("\n - classesUrl:\t" + classesUrl);
         result.append("\n - packagePrefix:\t" + packagePrefix);
+        result.append("\n - jettyRequestHeaderSize:\t" + jettyRequestHeaderSize);
 
         // Basic authentication
         result.append("\nBasic Auth:");
@@ -161,12 +169,37 @@ public class Configuration {
         String password = getValue(AUTH_PASSWORD);
         String realm = getValue(AUTH_REALM);
 
+        // server request header size:
+        String requestHeaderSize = getValue(JETTY_REQUEST_HEADER_SIZE);
+        // if the env var is not set use default value
+        if (StringUtils.isBlank(requestHeaderSize)) {
+            requestHeaderSize = Integer.toString(this.jettyRequestHeaderSize);
+        }
+
         // Set up the configuration:
         configurePort(port);
         configureMaxThreads(maxThreads);
         configureFiles(files);
         configureClasses(classes);
         configureAuthentication(username, password, realm);
+        configureJettyRequestHeaderSize(requestHeaderSize);
+    }
+
+    /**
+      * Configures the server request header size,
+      * default is 8192 bytes.
+      *
+      * @param requestHeaderSize The value of the {@value #JETTY_REQUEST_HEADER_SIZE} parameter.
+      */
+    void configureJettyRequestHeaderSize(String requestHeaderSize) {
+        if (StringUtils.isNotBlank(requestHeaderSize)) {
+            try {
+                this.jettyRequestHeaderSize = Integer.parseInt(requestHeaderSize);
+                log.info("Using jettyRequestHeaderSize {}", this.jettyRequestHeaderSize);
+            } catch (NumberFormatException e) {
+                log.info("Unable to parse server JETTY_REQUEST_HEADER_SIZE variable ({}). Defaulting to jettyRequestHeaderSize {}", requestHeaderSize, this.jettyRequestHeaderSize);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/github/davidcarboni/restolino/Main.java
+++ b/src/main/java/com/github/davidcarboni/restolino/Main.java
@@ -11,6 +11,7 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.http.HttpVersion;
 import org.slf4j.Logger;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -51,6 +52,7 @@ public class Main {
             ServerConnector http = new ServerConnector(server, new HttpConnectionFactory());
             http.setPort(configuration.port);
             server.addConnector(http);
+            configureRequestHeaderSize(http, configuration.jettyRequestHeaderSize);
 
             // Create the handlers
             mainHandler = new MainHandler();
@@ -95,6 +97,13 @@ public class Main {
         } finally {
             ClassReloader.shutdown();
         }
+    }
+
+    private static void configureRequestHeaderSize(ServerConnector connector, int headerSize) {
+        HttpConnectionFactory cf = (HttpConnectionFactory)
+                connector.getConnectionFactory(HttpVersion.HTTP_1_1.toString());
+        cf.getHttpConfiguration().setRequestHeaderSize(headerSize);
+        log.info("Configuring request header size to {}", headerSize);
     }
 
 }

--- a/src/test/java/com/github/davidcarboni/restolino/json/SerialiserTest.java
+++ b/src/test/java/com/github/davidcarboni/restolino/json/SerialiserTest.java
@@ -1,6 +1,7 @@
 package com.github.davidcarboni.restolino.json;
 
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -12,7 +13,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Tests for {@link Serialiser}.
@@ -71,7 +72,7 @@ public class SerialiserTest {
         // Then
         // All tasks should complete without exceptions
         for (Future<Exception> task : tasks) {
-            assertNull(task.get());
+            assertThrows(NullPointerException.class, (ThrowingRunnable) task.get());
         }
         // Sometimes another thread will have serialised before deserialisation:
         assertNotEquals(same.get(), different.get());

--- a/src/test/java/com/github/davidcarboni/restolino/json/SerialiserTest.java
+++ b/src/test/java/com/github/davidcarboni/restolino/json/SerialiserTest.java
@@ -1,7 +1,6 @@
 package com.github.davidcarboni.restolino.json;
 
 import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -13,7 +12,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for {@link Serialiser}.
@@ -72,7 +71,7 @@ public class SerialiserTest {
         // Then
         // All tasks should complete without exceptions
         for (Future<Exception> task : tasks) {
-            assertThrows(NullPointerException.class, (ThrowingRunnable) task.get());
+            assertNull(task.get());
         }
         // Sometimes another thread will have serialised before deserialisation:
         assertNotEquals(same.get(), different.get());


### PR DESCRIPTION
**What**

Added environment variable to configure http request header size limit for jetty.

**How to review**

- Checkout this branch.
- Run `mvn clean install`
- Make zebedee use local restolino we just installed
- cd into zebedee and run `mvn clean install`
- Run the auth stack. (First clean previous image of zebedee)
- Login to florence 
- Navigate to collections and try to change the value of the lang cookie to a long value
- You should see 431's coming back
- In your auth stack add `JETTY_REQUEST_HEADER_SIZE: 16384` under zebedee service environment
- Run `make down up SERVICE=zebedee`
- You should not see 431's coming back (except maybe from babbage)


**Who can review**

Anyone